### PR TITLE
Fix game bugs, enable all heroes, add music mute button

### DIFF
--- a/src/content/cards.js
+++ b/src/content/cards.js
@@ -1,4 +1,4 @@
-import { decks } from "./decks";
+import { decks } from "./decks/index.js";
 // Here you'll find all the default cards used in the game.
 // See game/cards.js for the details on how they work.
 export default [...decks.defaultDeck, ...decks.poison, ...decks.electric];

--- a/src/content/decks/index.js
+++ b/src/content/decks/index.js
@@ -1,5 +1,5 @@
-import { defaultDeck } from "./default";
-import { poison } from "./poison";
-import { electric } from "./electric";
+import { defaultDeck } from "./default.js";
+import { poison } from "./poison.js";
+import { electric } from "./electric.js";
 
 export const decks = { defaultDeck, poison, electric };

--- a/src/content/heroes.js
+++ b/src/content/heroes.js
@@ -25,7 +25,7 @@ export const heroes = [
   },
   {
     id: 2,
-    active: false,
+    active: true,
     name: "Specter",
     description:
       "Specter uses evasive manouvres and poisonous skills to win his battles.",
@@ -49,7 +49,7 @@ export const heroes = [
   },
   {
     id: 3,
-    active: false,
+    active: true,
     name: "Ice Cream",
     description:
       "General Ice Cream will obliterate enemies using his ice abilities!",
@@ -61,9 +61,9 @@ export const heroes = [
       "Battery Pills",
       "Battery Pills",
       "Battery Pills",
-      "Black Lightning",
-      "Thunder storm",
-      "Thunder storm",
+      "Power Surge",
+      "Thunder",
+      "Thunder",
     ],
     decks: ["defaultDeck", "poison", "electric"],
     type: "Ice",
@@ -73,9 +73,10 @@ export const heroes = [
   },
   {
     id: 4,
-    active: false,
+    active: true,
     name: "Sakura",
-    description: "Coming soon",
+    description:
+      "Sakura relies on a balanced deck of strikes and defends to outlast her enemies.",
     starterdeck: [
       "Defend",
       "Defend",

--- a/src/content/monsters/index.js
+++ b/src/content/monsters/index.js
@@ -1,4 +1,4 @@
-import { stage1Monsters } from "./stage1Monsters";
-import { stage2Monsters } from "./stage2Monsters";
+import { stage1Monsters } from "./stage1Monsters.js";
+import { stage2Monsters } from "./stage2Monsters.js";
 
 export const allMonsters = { stage1Monsters, stage2Monsters };

--- a/src/game/actions.js
+++ b/src/game/actions.js
@@ -150,7 +150,10 @@ function removeCard(state, { card }) {
  */
 function upgradeCard(state, { card }) {
   return produce(state, (draft) => {
-    draft.deck.find((c) => c.id === card.id).upgrade();
+    const cardInDeck = draft.deck.find((c) => c.id === card.id);
+    if (cardInDeck && typeof cardInDeck.upgrade === "function") {
+      cardInDeck.upgrade();
+    }
   });
 }
 
@@ -188,7 +191,7 @@ function useRelic(state, { relic }) {
       });
     case "addAttack":
       return produce(state, (draft) => {
-        draft.player.powers.boost = 8;
+        draft.player.powers.boost = relic.value;
       });
     case "addVulnerable":
       return produce(state, (draft) => {
@@ -225,7 +228,8 @@ function useRelic(state, { relic }) {
     case "addGold":
       return addGold(state, { gold: relic.value });
     default:
-      return;
+      // Unknown or passive relic actions don't change the state.
+      return state;
   }
 }
 
@@ -259,7 +263,9 @@ function playCard(state, { card, target }) {
       draft.player.block = newState.player.block + card.block;
     }
   });
-  if (card.type === "attack" || card.damage) {
+  // Attack cards without a `damage` prop (e.g. "Counter Slam") deal their
+  // damage through `actions` instead, so only run this for real damage values.
+  if ((card.type === "attack" || card.damage) && card.damage > 0) {
     // This should be refactored, but when you play an attack card that targets all enemies,
     // we prioritize this over the actual enemy where you dropped the card.
     const newTarget =
@@ -298,16 +304,15 @@ export function useCardActions(state, { target, card }) {
   let newState = state;
   card.actions.forEach((action) => {
     // Don't run action if it has an invalid condition.
-    if (action.conditions && !conditionsAreValid(action.conditions, state)) {
-      return newState;
+    if (action.conditions && !conditionsAreValid(action.conditions, newState)) {
+      return;
     }
-    // Make sure the action is called with a target.
-    if (!action.parameter) action.parameter = {};
-    // Prefer the target you dropped the card on.
-    action.parameter.target = target;
-    action.parameter.card = card;
-    // Run the action
-    newState = allActions[action.type](newState, action.parameter);
+    // A target defined on the action itself (e.g. "Soul Drain" damaging the player)
+    // wins over the target the card was dropped on.
+    const parameter = { ...action.parameter, card };
+    if (!parameter.target) parameter.target = target;
+    // Run the action. Actions that bail out may return undefined; keep the state.
+    newState = allActions[action.type](newState, parameter) || newState;
   });
   return newState;
 }
@@ -463,7 +468,11 @@ function addPlayerCharge(state, { amount }) {
 
 function transferDischargeToHealth(state) {
   return produce(state, (draft) => {
-    draft.player.currentHealth += draft.player.powers.charge;
+    draft.player.currentHealth = clamp(
+      draft.player.currentHealth + (draft.player.powers.charge || 0),
+      0,
+      draft.player.maxHealth
+    );
     draft.player.powers.charge = 0;
   });
 }
@@ -477,12 +486,12 @@ function applyPlayerPoison(state) {
   });
 }
 
-// Apply poison damage to target
+// Apply poison damage to target. Poison ignores block.
 function applyPoison(state, { target, index }) {
   if (target === "player") {
-    return removeHealth(state, {
-      target: `player`,
-      amount: state.player.powers.poison,
+    return produce(state, (draft) => {
+      draft.player.currentHealth =
+        draft.player.currentHealth - (draft.player.powers.poison || 0);
     });
   } else {
     return produce(state, (draft) => {
@@ -559,7 +568,7 @@ function newTurn(state) {
   let newState = drawCards(state);
   return produce(newState, (draft) => {
     draft.turn++;
-    draft.player.currentEnergy = 3;
+    draft.player.currentEnergy = draft.player.maxEnergy;
     draft.player.block = 0;
   });
 }
@@ -621,10 +630,10 @@ function takeMonsterTurn(state, monsterIndex) {
       );
 
       dodgeRelics.map((relic) => {
-        console.log("Triggering dodge relic: ", relic);
         const calc = Math.random() * 100;
         if (calc < 10) {
-          amount = "Dodged";
+          console.log("Dodged attack thanks to relic: ", relic);
+          amount = 0;
         }
       });
       if (monster.powers.weak) amount = powers.weak.use(amount);
@@ -671,7 +680,7 @@ function move(state, { move }) {
   return produce(nextState, (draft) => {
     // Clear temporary powers, energy and block on player.
     draft.player.powers = {};
-    draft.player.currentEnergy = 3;
+    draft.player.currentEnergy = draft.player.maxEnergy;
     draft.player.block = 0;
     draft.dungeon.graph[move.y][move.x].didVisit = true;
     draft.dungeon.pathTaken.push({ x: move.x, y: move.y });
@@ -697,6 +706,7 @@ function dealDamageEqualToBlock(state, { target }) {
     const block = state.player.block;
     return removeHealth(state, { target, amount: block });
   }
+  return state;
 }
 
 function dealDamageEqualToVulnerable(state, { target }) {
@@ -757,7 +767,7 @@ function dealDamageEqualToCharge(state, { target, multiplier, allTargets }) {
 
 function resetCharge(state) {
   return produce(state, (draft) => {
-    draft.player.power.charge = 0;
+    draft.player.powers.charge = 0;
   });
 }
 

--- a/src/game/cards.js
+++ b/src/game/cards.js
@@ -1,6 +1,6 @@
 import { uuid } from "./utils.js";
 import cards from "../content/cards.js";
-import { decks } from "../content/decks";
+import { decks } from "../content/decks/index.js";
 
 // This file contains the logic to create cards.
 // While cards are described in plain object form, they are always converted to a class equivalent.
@@ -68,10 +68,12 @@ export class Card {
     this.target = CardTargets[props.target];
     this.damage = props.damage;
     this.block = props.block;
-    this.powers = props.powers;
+    // Clone plain-data props so upgrading one card never mutates the shared
+    // content definitions (and with them every other copy of the card).
+    this.powers = props.powers && structuredClone(props.powers);
     this.description = props.description;
-    this.conditions = props.conditions;
-    this.actions = props.actions;
+    this.conditions = props.conditions && structuredClone(props.conditions);
+    this.actions = props.actions && structuredClone(props.actions);
     this.image = props.image;
     this.upgraded = false;
     if (props.upgrade) this.upgrade = props.upgrade;
@@ -102,6 +104,26 @@ export function createCard(name) {
   const baseCard = findCard(name);
   if (!baseCard) throw new Error(`Card not found: ${name}`);
   return new Card(baseCard);
+}
+
+/**
+ * Restores a card that was serialized to JSON (e.g. a saved game).
+ * JSON loses the class prototype and the per-card `upgrade` method,
+ * so we rebuild the card from its content definition and copy the
+ * saved values (id, upgraded stats, ...) back on top.
+ * @param {object} savedCard - plain object card from a save file
+ * @returns {CARD}
+ */
+export function rehydrateCard(savedCard) {
+  // Upgraded cards get a "+" suffix; fall back to the base name.
+  const base =
+    findCard(savedCard.name) || findCard(savedCard.name.replace(/\+$/, ""));
+  if (!base) {
+    // Renamed upgrades ("High Succube", ...) have no base card. Restoring the
+    // prototype at least gives them the default (no-op) upgrade method.
+    return Object.setPrototypeOf(savedCard, Card.prototype);
+  }
+  return Object.assign(new Card(base), savedCard);
 }
 
 /**

--- a/src/game/dungeon.js
+++ b/src/game/dungeon.js
@@ -34,7 +34,7 @@ const defaultOptions = {
  * @returns {DUNGEON}
  */
 export default function Dungeon(options = {}, state) {
-  options = Object.assign(defaultOptions, options);
+  options = Object.assign({}, defaultOptions, options);
 
   const graph = generateGraph(options);
   const paths = generatePaths(graph, options.customPaths);
@@ -135,7 +135,7 @@ function decideRoomType(nodeType, floor, state) {
  * @returns {array} - graph
  */
 export function generateGraph(options = {}) {
-  options = Object.assign(defaultOptions, options);
+  options = Object.assign({}, defaultOptions, options);
   const { height, width, minRooms, maxRooms } = options;
 
   function Node(type) {

--- a/src/game/utils-state.js
+++ b/src/game/utils-state.js
@@ -82,7 +82,8 @@ export function isStageCompleted(state) {
       });
     })
     .filter(Boolean);
-  return clearedRooms.length === state.dungeon.graph.length && state.stage < 9;
+  // The final stage counts as winning the dungeon, not "just" the stage.
+  return clearedRooms.length === state.dungeon.graph.length && state.stage < 2;
 }
 
 // Checks if the whole dungeon (all stages) has been cleared.

--- a/src/ui/app.js
+++ b/src/ui/app.js
@@ -9,7 +9,7 @@ import { Flip } from "../web_modules/gsap/Flip.js";
 // Game logic
 import createNewGame from "../game/new-game.js";
 
-import { getCardRewards } from "../game/cards.js";
+import { getCardRewards, rehydrateCard } from "../game/cards.js";
 import {
   getCurrRoom,
   isCurrRoomCompleted,
@@ -40,18 +40,35 @@ Object.keys(realSfx).forEach((key) => {
   sfx[key] = () => null;
 });
 
-const load = () =>
-  JSON.parse(decodeURIComponent(localStorage.getItem("saveGame")));
+// Loads a saved game and restores what JSON.stringify can't represent:
+// the dungeon node edges (Sets) and the card class methods.
+const load = () => {
+  const state = JSON.parse(decodeURIComponent(localStorage.getItem("saveGame")));
+  state.dungeon.graph.forEach((floor) =>
+    floor.forEach((node) => {
+      node.edges = new Set(Array.isArray(node.edges) ? node.edges : []);
+    })
+  );
+  ["deck", "drawPile", "hand", "discardPile"].forEach((pile) => {
+    state[pile] = state[pile].map(rehydrateCard);
+  });
+  return state;
+};
 
 export default class App extends Component {
   constructor() {
     super();
     // Props
     this.base = undefined;
-    this.state = { showStageName: false, displayShop: false };
+    this.state = {
+      showStageName: false,
+      displayShop: false,
+      musicMuted: localStorage.getItem("musicMuted") === "true",
+    };
     this.game = {};
     this.overlayIndex = 11;
     this.audio = new Audio();
+    this.audio.muted = this.state.musicMuted;
 
     // Scope methods
     this.playCard = this.playCard.bind(this);
@@ -67,6 +84,7 @@ export default class App extends Component {
     this.activateUltimate = this.activateUltimate.bind(this);
     this.isPlayerDead = this.isPlayerDead.bind(this);
     this.audioController = this.audioController.bind(this);
+    this.toggleMusic = this.toggleMusic.bind(this);
     this.buyItem = this.buyItem.bind(this);
   }
   componentDidMount() {
@@ -78,7 +96,13 @@ export default class App extends Component {
     sfx.startGame();
 
     // If there is a saved game state, use it.
-    const savedGameState = localStorage.getItem("saveGame") && load();
+    let savedGameState;
+    try {
+      savedGameState = localStorage.getItem("saveGame") && load();
+    } catch (err) {
+      console.warn("Could not load the saved game, starting a new one.", err);
+      localStorage.removeItem("saveGame");
+    }
     if (savedGameState) {
       this.game.state = savedGameState;
       this.setState(savedGameState, this.dealCards);
@@ -90,6 +114,7 @@ export default class App extends Component {
     // @ts-ignore
     window.df = {
       game: this.game,
+      audio: this.audio,
       update: this.update.bind(this),
       dealCards: this.dealCards.bind(this),
       money() {
@@ -342,19 +367,16 @@ export default class App extends Component {
       this.goToNextRoom();
     }
     setTimeout(() => {
-      this.checkRelicTrigger();
+      this.checkRelicTrigger(nft);
     }, 1000);
   }
-  checkRelicTrigger() {
-    const startRelics = this.state.relics.filter(
-      (item) => item.type === "start"
-    );
-    startRelics.map((relic) => {
-      console.log("Triggering battleStart relic: ", relic);
-
-      this.game.enqueue({ type: "useRelic", relic: relic });
+  // "start" relics trigger once, when they are picked up.
+  checkRelicTrigger(relic) {
+    if (relic && relic.type === "start") {
+      console.log("Triggering start relic: ", relic);
+      this.game.enqueue({ type: "useRelic", relic });
       this.update();
-    });
+    }
   }
   handleMapMove(move) {
     this.toggleOverlay("#Map");
@@ -382,7 +404,11 @@ export default class App extends Component {
         (item) => item.type === "death"
       );
       deathRelics.map((relic) => {
-        if (!this.state.player.usedRelics.includes(relic)) {
+        // Compare by name: object references don't survive immer/save-load.
+        const wasUsed = this.state.player.usedRelics.some(
+          (used) => used.name === relic.name
+        );
+        if (!wasUsed) {
           console.log("Triggering death relic: ", relic);
 
           this.game.enqueue({ type: "useRelic", relic: relic });
@@ -405,6 +431,20 @@ export default class App extends Component {
       amount: this.game.state.player.gold - cost,
     });
     this.update();
+  }
+  // Mutes/unmutes the background music and remembers the choice.
+  // Also pauses/resumes playback: if the browser blocked autoplay earlier,
+  // muting alone would be inaudible and the button would appear broken.
+  toggleMusic() {
+    const musicMuted = !this.state.musicMuted;
+    this.audio.muted = musicMuted;
+    if (musicMuted) {
+      this.audio.pause();
+    } else if (this.audio.src) {
+      this.audio.play().catch(() => {});
+    }
+    localStorage.setItem("musicMuted", String(musicMuted));
+    this.setState({ musicMuted });
   }
   audioController(room, trigger) {
     this.audio.volume = 0.15;
@@ -644,6 +684,10 @@ export default class App extends Component {
         </div>
 
 				
+
+          <button class="MuteButton" onClick=${() => this.toggleMusic()}>
+            ${state.musicMuted ? "🔇 Music: Off" : "🔊 Music: On"}
+          </button>
 
              <${OverlayWithButton} id="Map" topright key=${1}>
               <button disabled=${

--- a/src/ui/campfire.js
+++ b/src/ui/campfire.js
@@ -1,70 +1,57 @@
 import {
   html,
-  Component,
+  useState,
 } from "../web_modules/htm/preact/standalone.module.js";
 import CardChooser from "./card-chooser.js";
 
-export default class CampfireRoom extends Component {
-  rest() {
-    this.props.onChoose("rest");
-  }
-  choose(choice, reward) {
-    this.setState({
-      choice,
-      reward,
-      isChoosingCard: !this.state.isChoosingCard,
-    });
+export default function CampfireRoom(props) {
+  const [choice, setChoice] = useState(undefined);
+  const [isChoosingCard, setIsChoosingCard] = useState(false);
+
+  function choose(newChoice, reward) {
+    setChoice(newChoice);
+    setIsChoosingCard((choosing) => !choosing);
     if (reward) {
-      this.props.onChoose(choice, reward);
+      props.onChoose(newChoice, reward);
     }
   }
-  onSelectCard(card) {
-    this.choose(this.state.choice, card);
-  }
 
-  render(props, state) {
-    const { gameState } = props;
-    const { choice, isChoosingCard } = state;
-    let label = "";
-    if (choice === "upgradeCard") label = "Choose a card to upgrade";
-    if (choice === "removeCard") label = "Choose a card to remove";
-    return html`
-      <h1 center medium>Campfire</h1>
-      <ul class="Options campfire">
-        ${isChoosingCard
-          ? html`
-              <li>
-                <button
-                  onclick=${() => this.setState({ isChoosingCard: false })}
-                >
-                  Cancel
-                </button>
-              </li>
-            `
-          : html`
-              <li>
-                <button onclick=${() => this.rest()}>Rest</button>
-              </li>
-              <li>
-                <button onclick=${() => this.choose("upgradeCard")}>
-                  Upgrade card
-                </button>
-              </li>
-              <li>
-                <button onclick=${() => this.choose("removeCard")}>
-                  Remove card
-                </button>
-              </li>
-            `}
-      </ul>
-      ${isChoosingCard &&
-      html`<br />
-        <p center>${label}</p>
-        <${CardChooser}
-          gameState=${gameState}
-          cards=${gameState.deck}
-          didSelectCard=${(card) => this.onSelectCard(card)}
-        />`}
-    `;
-  }
+  let label = "";
+  if (choice === "upgradeCard") label = "Choose a card to upgrade";
+  if (choice === "removeCard") label = "Choose a card to remove";
+
+  return html`
+    <h1 center medium>Campfire</h1>
+    <ul class="Options campfire">
+      ${isChoosingCard
+        ? html`
+            <li>
+              <button onclick=${() => setIsChoosingCard(false)}>Cancel</button>
+            </li>
+          `
+        : html`
+            <li>
+              <button onclick=${() => props.onChoose("rest")}>Rest</button>
+            </li>
+            <li>
+              <button onclick=${() => choose("upgradeCard")}>
+                Upgrade card
+              </button>
+            </li>
+            <li>
+              <button onclick=${() => choose("removeCard")}>
+                Remove card
+              </button>
+            </li>
+          `}
+    </ul>
+    ${isChoosingCard &&
+    html`<br />
+      <p center>${label}</p>
+      <${CardChooser}
+        gameState=${props.gameState}
+        cards=${props.gameState.deck}
+        didSelectCard=${(card) => choose(choice, card)}
+      />`}
+  `;
 }

--- a/src/ui/card-chooser.js
+++ b/src/ui/card-chooser.js
@@ -1,34 +1,30 @@
-import {
-  html,
-  Component,
-} from "../web_modules/htm/preact/standalone.module.js";
+import { html } from "../web_modules/htm/preact/standalone.module.js";
 import { Card } from "./cards.js";
 
-export default class CardChooser extends Component {
-  clickedCard(card) {
-    this.props.didSelectCard(card);
-    if (this.props.isShop) {
+export default function CardChooser(props) {
+  function clickedCard(card) {
+    props.didSelectCard(card);
+    if (props.isShop) {
       const el = document.getElementById(card.name);
       el.style.pointerEvents = "none";
       el.style.filter = "grayscale(1)";
     }
   }
-  render(props) {
-    return html`
-      <article class="RewardsBox">
-        <div class="Cards">
-          ${props.cards.map(
-            (card) =>
-              html`<div
-                class="CardBox"
-                id=${card.name}
-                onClick=${() => this.clickedCard(card)}
-              >
-                ${Card(card, props.gameState)}
-              </div>`
-          )}
-        </div>
-      </article>
-    `;
-  }
+
+  return html`
+    <article class="RewardsBox">
+      <div class="Cards">
+        ${props.cards.map(
+          (card) =>
+            html`<div
+              class="CardBox"
+              id=${card.name}
+              onClick=${() => clickedCard(card)}
+            >
+              ${Card(card, props.gameState)}
+            </div>`
+        )}
+      </div>
+    </article>
+  `;
 }

--- a/src/ui/cards.js
+++ b/src/ui/cards.js
@@ -1,19 +1,14 @@
-import {
-  html,
-  Component,
-} from "../web_modules/htm/preact/standalone.module.js";
+import { html } from "../web_modules/htm/preact/standalone.module.js";
 import { canPlay } from "../game/conditions.js";
 
-export default class Cards extends Component {
-  // props = {gameState: {}, type ''}
-  render(props) {
-    const cards = props.gameState[props.type];
-    return html`
-      <div class="Cards">
-        ${cards.map((card, index) => Card(card, props.gameState, index))}
-      </div>
-    `;
-  }
+// Renders a list of cards from the gameState prop, e.g. type="hand" or "deck".
+export default function Cards(props) {
+  const cards = props.gameState[props.type];
+  return html`
+    <div class="Cards">
+      ${cards.map((card, index) => Card(card, props.gameState, index))}
+    </div>
+  `;
 }
 
 export function Card(card, gameState, index) {
@@ -25,6 +20,9 @@ export function Card(card, gameState, index) {
   const image = card.image
     ? `/images/cards/allCards/${card.image}`
     : "/images/cards/allCards/placeholder.webp";
+  const style = `background:url(${image});background-size:cover;${
+    isMobile ? `left:calc(0px + 70px * ${index});` : ""
+  }`;
 
   return html` <article
     class="Card ${card.upgraded ? "upgraded" : ""}"
@@ -33,41 +31,13 @@ export function Card(card, gameState, index) {
     key=${card.id}
     data-id=${card.id}
     disabled=${isDisabled}
-    style="background: url("${image}");background-size:cover;${
-    isMobile && `left:calc(0px + 70px * ${index});`
-  }"
+    style=${style}
   >
-  ${
-    !card.image &&
+    ${!card.image &&
     html` <p class="Card-energy EnergyBadge">
         <span>${card.energy}</span>
       </p>
       <h3 class="Card-name">${card.name}</h3>
-      <p class="Card-description">${card.description}</p>`
-  }
-
-
+      <p class="Card-description">${card.description}</p>`}
   </article>`;
-  return html`
-    <article
-      class="Card"
-      data-card-type=${card.type}
-      data-card-target=${card.target}
-      key=${card.id}
-      data-id=${card.id}
-      disabled=${isDisabled}
-    >
-      <div class="Card-inner">
-        <p class="Card-energy EnergyBadge">
-          <span>${card.energy}</span>
-        </p>
-        <h3 class="Card-name">${card.name}</h3>
-        <figure class="Card-media">
-          <img src=${image} alt=${card.name} />
-        </figure>
-        <p class="Card-type">${card.type}</p>
-        <p class="Card-description">${card.description}</p>
-      </div>
-    </article>
-  `;
 }

--- a/src/ui/decks.js
+++ b/src/ui/decks.js
@@ -1,47 +1,35 @@
 import {
   html,
-  Component,
+  useState,
 } from "../web_modules/htm/preact/standalone.module.js";
-import cards from "../content/cards.js";
 import { Card } from "./cards.js";
-import { decks as D } from "../content/decks";
+import { decks as D } from "../content/decks/index.js";
 
-export default class Decks extends Component {
-  constructor() {
-    super();
-    this.state = {
-      selectedDeck: "defaultDeck",
-    };
-    this.handleSelectedDeck = this.handleSelectedDeck.bind(this);
-  }
-  handleSelectedDeck(deck) {
-    this.setState({ selectedDeck: deck });
-  }
-  render(props, state) {
-    const deckNames = Object.keys(D);
+export default function Decks(props) {
+  const [selectedDeck, setSelectedDeck] = useState("defaultDeck");
+  const deckNames = Object.keys(D);
 
-    return html`
-      <article class="Splash Splash--fadein">
-        <h1 style="margin-top:8vh">Decks</h1>
-        <article>
-          <p><a onclick=${props.back} class="Button">Back</a></p>
-          <div class="decks">
-            ${deckNames.map(
-              (deck) =>
-                html`<button onclick=${() => this.handleSelectedDeck(deck)}>
-                  ${deck}
-                </button>`
-            )}
-          </div>
-          <h2>${this.state.selectedDeck}</h2>
+  return html`
+    <article class="Splash Splash--fadein">
+      <h1 style="margin-top:8vh">Decks</h1>
+      <article>
+        <p><a onclick=${props.back} class="Button">Back</a></p>
+        <div class="decks">
+          ${deckNames.map(
+            (deck) =>
+              html`<button onclick=${() => setSelectedDeck(deck)}>
+                ${deck}
+              </button>`
+          )}
+        </div>
+        <h2>${selectedDeck}</h2>
 
-          <h2>${D[this.state.selectedDeck].length} Card Collection</h2>
+        <h2>${D[selectedDeck].length} Card Collection</h2>
 
-          <div class="Cards Cards--grid">
-            ${D[this.state.selectedDeck].map((card) => Card(card))}
-          </div>
-        </article>
+        <div class="Cards Cards--grid">
+          ${D[selectedDeck].map((card) => Card(card))}
+        </div>
       </article>
-    `;
-  }
+    </article>
+  `;
 }

--- a/src/ui/dungeon-stats.js
+++ b/src/ui/dungeon-stats.js
@@ -1,7 +1,4 @@
-import {
-  html,
-  Component,
-} from "../web_modules/htm/preact/standalone.module.js";
+import { html } from "../web_modules/htm/preact/standalone.module.js";
 
 export const getEnemiesStats = (dungeon) => {
   const stats = {
@@ -31,18 +28,16 @@ export const getEnemiesStats = (dungeon) => {
   return stats;
 };
 
-export default class DungeonStats extends Component {
-  render({ state }) {
-    const { dungeon } = state;
-    const stats = getEnemiesStats(dungeon);
-    return html`
-      <h2>Dungeon stats</h2>
-      <ul>
-        <li>Enemies encountered: ${stats.encountered}</li>
-        <li>Enemies killed: ${stats.killed}</li>
-        <li>Total enemies health: ${stats.maxHealth}</li>
-        <li>Final health count: ${stats.finalHealth}</li>
-      </ul>
-    `;
-  }
+export default function DungeonStats({ state }) {
+  const { dungeon } = state;
+  const stats = getEnemiesStats(dungeon);
+  return html`
+    <h2>Dungeon stats</h2>
+    <ul>
+      <li>Enemies encountered: ${stats.encountered}</li>
+      <li>Enemies killed: ${stats.killed}</li>
+      <li>Total enemies health: ${stats.maxHealth}</li>
+      <li>Final health count: ${stats.finalHealth}</li>
+    </ul>
+  `;
 }

--- a/src/ui/index.js
+++ b/src/ui/index.js
@@ -1,12 +1,11 @@
 import {
   html,
-  render,
-  Component,
+  useState,
 } from "../web_modules/htm/preact/standalone.module.js";
 import App from "./app.js";
 import SplashScreen from "./splash-screen.js";
 import WinScreen from "./win-screen.js";
-import Decks from "./decks";
+import Decks from "./decks.js";
 
 /** @enum {string} */
 const GameModes = {
@@ -20,46 +19,30 @@ const GameModes = {
  * Our root component for the game.
  * Controls what to render.
  */
-export class SlayTheWeb extends Component {
-  constructor() {
-    super();
-    this.state = {
-      // The game mode to start in.
-      gameMode: GameModes.splash,
-    };
-    this.handleWin = this.handleWin.bind(this);
-    this.handleNewGame = this.handleNewGame.bind(this);
-    this.handleLoose = this.handleLoose.bind(this);
-    this.handleDecks = this.handleDecks.bind(this);
-  }
+export function SlayTheWeb() {
+  const [gameMode, setGameMode] = useState(GameModes.splash);
 
-  handleNewGame() {
-    this.setState({ gameMode: GameModes.gameplay });
-    localStorage.setItem("saveGame", "");
-  }
-  handleWin() {
-    this.setState({ gameMode: GameModes.win });
-  }
-  handleLoose() {
-    this.setState({ gameMode: GameModes.splash });
-  }
-  handleDecks() {
-    this.setState({ gameMode: GameModes.decks });
-  }
-  render(props, { gameMode }) {
-    if (gameMode === GameModes.splash)
-      return html`<${SplashScreen}
-        onNewGame=${this.handleNewGame}
-        onContinue=${this.handleNewGame}
-        openDecks=${this.handleDecks}
-      />`;
-    if (gameMode === GameModes.decks)
-      return html`<${Decks} back=${this.handleLoose} />`;
-    if (gameMode === GameModes.gameplay)
-      return html`
-        <${App} onWin=${this.handleWin} onLoose=${this.handleLoose} />
-      `;
-    if (gameMode === GameModes.win)
-      return html` <${WinScreen} onNewGame=${this.handleNewGame} /> `;
-  }
+  // A new game starts from scratch, so any old save is removed first.
+  const handleNewGame = () => {
+    localStorage.removeItem("saveGame");
+    setGameMode(GameModes.gameplay);
+  };
+  // Continuing keeps the save so the App can pick it up.
+  const handleContinue = () => setGameMode(GameModes.gameplay);
+  const handleWin = () => setGameMode(GameModes.win);
+  const handleLoose = () => setGameMode(GameModes.splash);
+  const handleDecks = () => setGameMode(GameModes.decks);
+
+  if (gameMode === GameModes.splash)
+    return html`<${SplashScreen}
+      onNewGame=${handleNewGame}
+      onContinue=${handleContinue}
+      openDecks=${handleDecks}
+    />`;
+  if (gameMode === GameModes.decks)
+    return html`<${Decks} back=${handleLoose} />`;
+  if (gameMode === GameModes.gameplay)
+    return html` <${App} onWin=${handleWin} onLoose=${handleLoose} /> `;
+  if (gameMode === GameModes.win)
+    return html` <${WinScreen} onNewGame=${handleNewGame} /> `;
 }

--- a/src/ui/map.js
+++ b/src/ui/map.js
@@ -161,7 +161,8 @@ export class SlayMap extends Component {
                   current=${isCurrent}
                   can-visit=${Boolean(canVisit)}
                   did-visit=${node.didVisit}
-                  onClick=${() => props.onSelect({ x: nodeIndex, y: rowIndex })}
+                  onClick=${() =>
+                    canVisit && props.onSelect({ x: nodeIndex, y: rowIndex })}
                 >
                   <span>${emojiFromNodeType(node.type)}</span>
                 </slay-map-node>`;

--- a/src/ui/menu.js
+++ b/src/ui/menu.js
@@ -1,8 +1,17 @@
 import { html } from "../web_modules/htm/preact/standalone.module.js";
 import History from "./history.js";
 
+// JSON has no Set type, so serialize the dungeon node edges as arrays.
+// They are restored in app.js when the save is loaded.
 const save = (state) =>
-  localStorage.setItem("saveGame", encodeURIComponent(JSON.stringify(state)));
+  localStorage.setItem(
+    "saveGame",
+    encodeURIComponent(
+      JSON.stringify(state, (key, value) =>
+        value instanceof Set ? [...value] : value
+      )
+    )
+  );
 const abandonGame = () => window.location.reload();
 
 export default function Menu({ game, gameState, onUndo }) {
@@ -12,7 +21,7 @@ export default function Menu({ game, gameState, onUndo }) {
 
       <ul class="Options">
         <li>
-          <button onclick=${() => save(gameState)}>Save</button>
+          <button onclick=${() => save(game.state)}>Save</button>
         </li>
         <li>
           <button onclick=${() => abandonGame()}>Abandon Game</button>

--- a/src/ui/quest.js
+++ b/src/ui/quest.js
@@ -1,45 +1,45 @@
 import {
   html,
-  Component,
+  useState,
 } from "../web_modules/htm/preact/standalone.module.js";
 import relics from "../content/relics.js";
 
-export default class QuestRoom extends Component {
-  render(props, state) {
+export default function QuestRoom(props) {
+  // Pick the three relics once, so re-renders don't reshuffle them.
+  const [randomRelics] = useState(() => {
     const owned = props.gameState.relics.map((rel) => rel.relicDescription);
     const available = relics.filter(
       (relic) => !owned.includes(relic.relicDescription)
     );
-    const shuffled = [...available].sort(() => 0.5 - Math.random()); //shuffle relics
-    const randomRelics = shuffled.slice(0, 3); // pick 3
+    return [...available].sort(() => 0.5 - Math.random()).slice(0, 3);
+  });
 
-    return html`
-      <h1 center medium>Event room</h1>
-      <p center>Aren't you a lucky one, you're allowed to choose a relic!</p>
-      ${randomRelics.length
-        ? html`
-            <div class="Cards Cards--grid">
-              ${randomRelics.map((relic) => {
-                return html` <article class="Card relic-card">
-                  <div
-                    class="Card-inner"
-                    onClick=${() => this.props.selectRelic(relic)}
-                  >
-                    <h3 class="Card-name">${relic.name}</h3>
-                    <figure class="Card-media relic">
-                      <img src="/images/${relic.image}" alt=${relic.name} />
-                    </figure>
-                    <p class="Card-type">Relic</p>
-                    <p class="Card-description">${relic.relicDescription}</p>
-                  </div>
-                </article>`;
-              })}
-            </div>
-          `
-        : html` <p center>No relics left to collect</p>
-            <div center>
-              <button onClick=${() => this.props.onContinue()}>Continue</button>
-            </div>`}
-    `;
-  }
+  return html`
+    <h1 center medium>Event room</h1>
+    <p center>Aren't you a lucky one, you're allowed to choose a relic!</p>
+    ${randomRelics.length
+      ? html`
+          <div class="Cards Cards--grid">
+            ${randomRelics.map((relic) => {
+              return html` <article class="Card relic-card">
+                <div
+                  class="Card-inner"
+                  onClick=${() => props.selectRelic(relic)}
+                >
+                  <h3 class="Card-name">${relic.name}</h3>
+                  <figure class="Card-media relic">
+                    <img src="/images/${relic.image}" alt=${relic.name} />
+                  </figure>
+                  <p class="Card-type">Relic</p>
+                  <p class="Card-description">${relic.relicDescription}</p>
+                </div>
+              </article>`;
+            })}
+          </div>
+        `
+      : html` <p center>No relics left to collect</p>
+          <div center>
+            <button onClick=${() => props.onContinue()}>Continue</button>
+          </div>`}
+  `;
 }

--- a/src/ui/splash-screen.js
+++ b/src/ui/splash-screen.js
@@ -1,35 +1,30 @@
-import {
-  html,
-  Component,
-} from "../web_modules/htm/preact/standalone.module.js";
+import { html } from "../web_modules/htm/preact/standalone.module.js";
 
-export default class SplashScreen extends Component {
-  render(props, state) {
-    const isMobile = navigator.userAgent.match(
-      /Android|BlackBerry|iPhone|iPad|iPod|Opera Mini|IEMobile/i
-    );
-    return html`
-      <article class="Splash Splash--fadein">
-        <div class="title-container">
-          <h1>Down<span class="titlep2">fall</span></h1>
-        </div>
-        <h2>The Dungeon Crawler Card Game</h2>
-      </article>
-      <ul class="Options ${isMobile ? "mobile" : ""}">
-        ${localStorage.getItem("saveGame")
-          ? html`
-              <li>
-                <button onClick=${props.onContinue}>Continue Game</button>
-              </li>
-              <li><button onClick=${props.onNewGame}>New Game</button></li>
-            `
-          : html`<li>
-              <button onClick=${props.onNewGame}>Play</button>
-            </li>`}
-        <li>
-          <button onClick=${props.openDecks}>Cards</button>
-        </li>
-      </ul>
-    `;
-  }
+export default function SplashScreen(props) {
+  const isMobile = navigator.userAgent.match(
+    /Android|BlackBerry|iPhone|iPad|iPod|Opera Mini|IEMobile/i
+  );
+  return html`
+    <article class="Splash Splash--fadein">
+      <div class="title-container">
+        <h1>Down<span class="titlep2">fall</span></h1>
+      </div>
+      <h2>The Dungeon Crawler Card Game</h2>
+    </article>
+    <ul class="Options ${isMobile ? "mobile" : ""}">
+      ${localStorage.getItem("saveGame")
+        ? html`
+            <li>
+              <button onClick=${props.onContinue}>Continue Game</button>
+            </li>
+            <li><button onClick=${props.onNewGame}>New Game</button></li>
+          `
+        : html`<li>
+            <button onClick=${props.onNewGame}>Play</button>
+          </li>`}
+      <li>
+        <button onClick=${props.openDecks}>Cards</button>
+      </li>
+    </ul>
+  `;
 }

--- a/src/ui/start-room.js
+++ b/src/ui/start-room.js
@@ -1,113 +1,107 @@
 import {
   html,
-  Component,
+  useState,
+  useEffect,
 } from "../web_modules/htm/preact/standalone.module.js";
 import relics from "../content/relics.js";
 import { heroes } from "../content/heroes.js";
 
-export default class StartRoom extends Component {
-  constructor() {
-    super();
-    this.state = {
-      heroSelected: false,
-      displayStage: false,
-      selectedHero: heroes[0],
-    };
-    this.startGame = this.startGame.bind(this);
-  }
-  componentDidMount() {
-    this.props.audio("start", "play");
-  }
+export default function StartRoom(props) {
+  const [heroSelected, setHeroSelected] = useState(false);
+  const [displayStage, setDisplayStage] = useState(false);
+  const [selectedHero, setSelectedHero] = useState(heroes[0]);
+  // Pick the three relics once, so re-renders don't reshuffle them.
+  const [randomRelics] = useState(() =>
+    [...relics].sort(() => 0.5 - Math.random()).slice(0, 3)
+  );
 
-  startGame(relic) {
-    this.setState({ displayStage: true });
+  useEffect(() => {
+    props.audio("start", "play");
+  }, []);
+
+  function startGame(relic) {
+    setDisplayStage(true);
     setTimeout(() => {
-      this.props.selectRelic(relic);
+      props.selectRelic(relic);
     }, 2000);
   }
 
-  render() {
-    const shuffled = [...relics].sort(() => 0.5 - Math.random()); //shuffle relics
-    const randomRelics = shuffled.slice(0, 3); // pick 3
-
-    return html`
-      <article
-        class="start-room"
-        style="background-image:url(/images/heroes/backgrounds/${this.state
-          .selectedHero.background});"
-      >
-        ${!this.state.heroSelected &&
-        html`
-          <p class="hero-btns">
-            <button onclick=${() => window.location.reload()}>Leave</button>
-            <button
-              onclick=${() => {
-                this.props.onSelect(this.state.selectedHero);
-                this.setState({ heroSelected: true });
-              }}
-            >
-              Next
-            </button>
-          </p>
-          <h1 center medium>Select Hero</h1>
-          <div class="selected-hero">
-            <img src="/images/heroes/${this.state.selectedHero.image}" />
-            <h3>${this.state.selectedHero.name}</h3>
-            <p>Deck type: ${this.state.selectedHero.type}</p>
-          </div>
-          <div class="hero-container">
-            ${heroes.map((hero) => {
-              return html`
-                <div
-                  class="hero-select ${!hero.active && "disabled"} ${this.state
-                    .selectedHero.id === hero.id
-                    ? "active"
-                    : ""}"
+  return html`
+    <article
+      class="start-room"
+      style="background-image:url(/images/heroes/backgrounds/${selectedHero.background});"
+    >
+      ${!heroSelected &&
+      html`
+        <p class="hero-btns">
+          <button onclick=${() => window.location.reload()}>Leave</button>
+          <button
+            onclick=${() => {
+              props.onSelect(selectedHero);
+              setHeroSelected(true);
+            }}
+          >
+            Next
+          </button>
+        </p>
+        <h1 center medium>Select Hero</h1>
+        <div class="selected-hero">
+          <img src="/images/heroes/${selectedHero.image}" />
+          <h3>${selectedHero.name}</h3>
+          <p>Deck type: ${selectedHero.type}</p>
+        </div>
+        <div class="hero-container">
+          ${heroes.map((hero) => {
+            return html`
+              <div
+                class="hero-select ${hero.active ? "" : "disabled"} ${selectedHero.id ===
+                hero.id
+                  ? "active"
+                  : ""}"
+              >
+                <a
+                  onClick=${() => {
+                    if (hero.active) setSelectedHero(hero);
+                  }}
                 >
-                  <a
-                    onClick=${() => {
-                      this.setState({ selectedHero: hero });
-                    }}
-                  >
-                    <img src="/images/heroes/thumbnails/${hero.thumbnail}" />
-                  </a>
-                </div>
-              `;
-            })}
+                  <img src="/images/heroes/thumbnails/${hero.thumbnail}" />
+                </a>
+              </div>
+            `;
+          })}
+        </div>
+      `}
+      ${heroSelected &&
+      html`
+        <h1 center medium>Select Relic</h1>
+        <p center>
+          Relics will give you a little boost on your descent so collect as
+          many as you can!
+        </p>
+        <div class="Cards Cards--grid">
+          ${randomRelics.map((relic) => {
+            return html` <article class="Card relic-card">
+              <div class="Card-inner" onClick=${() => startGame(relic)}>
+                <h3 class="Card-name">${relic.name}</h3>
+                <figure class="Card-media relic">
+                  <img src="/images/${relic.image}" alt=${relic.name} />
+                </figure>
+                <p class="Card-type">Relic</p>
+                <p class="Card-description">${relic.relicDescription}</p>
+              </div>
+            </article>`;
+          })}
+        </div>
+      `}
+      ${displayStage &&
+      html`
+        <div class="stage-start">
+          <div class="stage-start-content">
+            <h2>Stage 1</h2>
+            <h1>Limbo</h1>
           </div>
-        `}
-        ${this.state.heroSelected &&
-        html`
-          <h1 center medium>Select Relic</h1>
-          <p center>
-            Relics will give you a little boost on your descent so collect as
-            many as you can!
-          </p>
-          <div class="Cards Cards--grid">
-            ${randomRelics.map((relic) => {
-              return html` <article class="Card relic-card">
-                <div class="Card-inner" onClick=${() => this.startGame(relic)}>
-                  <h3 class="Card-name">${relic.name}</h3>
-                  <figure class="Card-media relic">
-                    <img src="/images/${relic.image}" alt=${relic.name} />
-                  </figure>
-                  <p class="Card-type">Relic</p>
-                  <p class="Card-description">${relic.relicDescription}</p>
-                </div>
-              </article>`;
-            })}
-          </div>
-        `}
-        ${this.state.displayStage &&
-        html`
-          <div class="stage-start">
-            <div class="stage-start-content">
-              <h2>Stage 1</h2>
-              <h1>Limbo</h1>
-            </div>
-          </div>
-        `}
-      </article>
-    `;
-  }
+        </div>
+      `}
+    </article>
+  `;
 }

--- a/src/ui/styles/overlay.css
+++ b/src/ui/styles/overlay.css
@@ -39,6 +39,25 @@
 	bottom: 0;
 	right: 0;
 }
+/* The background music mute toggle. Styled like the overlay corner buttons,
+   sitting left of the Deck button. High z-index so it's reachable in the
+   start room too, where the music begins. */
+.MuteButton {
+	font-size: 1rem;
+	position: absolute;
+	top: 0;
+	right: 10rem;
+	padding: 0.8rem;
+	user-select: none;
+	/* Above the start room and any opened overlay, so the music is
+	   controllable from everywhere. */
+	z-index: 9999;
+	background: none;
+	border: 0;
+	color: var(--text);
+	box-shadow: none;
+	cursor: pointer;
+}
 .Overlay-content {
 	position: absolute;
 	top: 100%;

--- a/src/ui/win-screen.js
+++ b/src/ui/win-screen.js
@@ -3,7 +3,7 @@ import {html} from '../web_modules/htm/preact/standalone.module.js'
 const WinScreen = (props) => html`
 	<article class="Splash">
 		<h1>Well done. You won.</h1>
-		<p><button autofocus onClick=${props.onNewGame}>Play again</a></p>
+		<p><button autofocus onClick=${props.onNewGame}>Play again</button></p>
 	</article>
 `
 


### PR DESCRIPTION
Fixes a broad set of gameplay and save/load bugs: "Continue Game" no longer wipes the save, dungeon maps survive serialization (Sets), cards keep their upgrade methods after loading, card upgrades no longer mutate shared definitions, Soul Drain/Counter Slam/dodge-relic NaN and lost-state bugs are resolved, start relics only trigger once, and the map no longer allows free teleporting.

Enables all four heroes — Ice Cream's starter deck referenced cards that don't exist and would have crashed hero select.

Adds a persisted background-music mute button that pauses/resumes playback.

Also converts the simple class components to functional hooks components (App and other lifecycle-heavy ones stay classes) and makes all source imports use explicit .js extensions so the game logic runs headless in Node.

Validated with a headless Node game-logic test suite, a production build, and scripted headless-browser playthroughs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)